### PR TITLE
support building against jdk 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,9 @@
-buildPlugin(tests: [skip: 'true'])
+def jenkinsVersion = '2.277.4'
+
+def configurations = [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "linux", jdk: "8", jenkins: jenkinsVersion ],
+  [ platform: "linux", jdk: "11", jenkins: jenkinsVersion, javaLevel: "8"]
+]
+
+buildPlugin(configurations: configurations, timeout: 180, tests: [skip: 'true'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ def jenkinsVersion = '2.277.4'
 def configurations = [
   [ platform: "linux", jdk: "8", jenkins: null ],
   [ platform: "linux", jdk: "8", jenkins: jenkinsVersion ],
-  [ platform: "linux", jdk: "11", jenkins: jenkinsVersion, javaLevel: "8"]
+  [ platform: "linux", jdk: "11", jenkins: jenkinsVersion ]
 ]
 
 buildPlugin(configurations: configurations, timeout: 180, tests: [skip: 'true'])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.36</version>
+    <version>4.42</version>
     <relativePath />
   </parent>
 
@@ -17,7 +17,7 @@
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jenkins.version>1.625.3</jenkins.version>
+    <jenkins.version>2.277.4</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -76,48 +76,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
       <version>1.7</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-step-api</artifactId>
-      <version>2.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-cps</artifactId>
-      <version>2.39</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-job</artifactId>
-      <version>2.11.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-basic-steps</artifactId>
-      <version>2.6</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.13</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-api</artifactId>
-      <version>2.20</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-support</artifactId>
-      <version>2.14</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/jenkins/plugins/mvn_snapshot_check/MavenSnapshotCheck.java
+++ b/src/main/java/jenkins/plugins/mvn_snapshot_check/MavenSnapshotCheck.java
@@ -18,7 +18,7 @@ import org.apache.tools.ant.types.FileSet;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.util.regex.Matcher;
@@ -113,7 +113,7 @@ public class MavenSnapshotCheck extends Builder implements SimpleBuildStep{
      * @param taskListener
      */
     @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener taskListener) {
+    public void perform(@NonNull Run<?, ?> run, @NonNull FilePath workspace, @NonNull Launcher launcher, @NonNull TaskListener taskListener) {
         if (getCheck()) {
             run.addAction(new MavenSnapshotCheckAction(CHECKED));
             String message = "[Maven SNAPSHOT Check], pomFiles: " + getPomFiles();

--- a/src/main/java/jenkins/plugins/mvn_snapshot_check/MavenSnapshotCheck.java
+++ b/src/main/java/jenkins/plugins/mvn_snapshot_check/MavenSnapshotCheck.java
@@ -145,7 +145,7 @@ public class MavenSnapshotCheck extends Builder implements SimpleBuildStep{
      * The class is marked as public so that it can be accessed from views.
      *
      * <p>
-     * See <tt>src/main/resources/hudson/plugins/hello_world/HelloWorldBuilder/*.jelly</tt>
+     * See <code>src/main/resources/jenkins/plugins/mvn_snapshot_check/MavenSnapshotCheck/config.jelly</code>
      * for the actual HTML fragment for the configuration screen.
      */
     @Symbol("mavenSnapshotCheck")


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
There are compliation error in `maven-cd/release` job: 
```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] java.nio.file.NoSuchFileException: /home/runner/work/maven-snapshot-check-plugin/maven-snapshot-check-plugin/target/classes/META-INF/annotations/org.jenkinsci.Symbol
[ERROR] java.nio.file.NoSuchFileException: /home/runner/work/maven-snapshot-check-plugin/maven-snapshot-check-plugin/target/classes/META-INF/annotations/hudson.Extension
```
Because  the `maven-cd/release` job runs on jdk 11, so this plugin shoud support for jdk 11.

Changes:
1. bump parent-pom version to 4.42
2. bump jenkins.version to 2.277.4
3. remove unused dependency
4. replace `javax.annotation.Nonnull` with `edu.umd.cs.findbugs.annotations.NonNull`,  because `javax.annotation` was removed from jdk 11

Reference:
- https://github.com/jenkinsci/clif-performance-testing-plugin/pull/14
- https://github.com/jenkinsci/configuration-as-code-plugin/pull/808


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
