### PR TITLE
Use `jenkins.baseline` to reduce bom update mistakes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.332</jenkins.baseline>
+    <jenkins.baseline>2.361</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <java.level>8</java.level>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-{jenkins.baseline}.x</artifactId>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
         <version>1763.v092b_8980a_f5e</version>
         <scope>import</scope>
         <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.361</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,9 @@
     <revision>1</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jenkins.version>2.361</jenkins.version>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.332</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -25,7 +27,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
+        <artifactId>bom-{jenkins.baseline}.x</artifactId>
         <version>1763.v092b_8980a_f5e</version>
         <scope>import</scope>
         <type>pom</type>


### PR DESCRIPTION
## Use `jenkins.baseline` in `pom.xml`

This change is proposed by the plugin archetype and makes maintenance of `jenkins.version` and `bom` a little easier.

### Testing done

None. Rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
