### PR TITLE
Migrate from Commons Lang to native Java Platform functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 

--- a/src/main/java/jenkins/plugins/mvn_snapshot_check/MavenSnapshotCheck.java
+++ b/src/main/java/jenkins/plugins/mvn_snapshot_check/MavenSnapshotCheck.java
@@ -3,6 +3,7 @@ package jenkins.plugins.mvn_snapshot_check;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.Util;
 import hudson.Launcher;
 import hudson.model.*;
 import hudson.remoting.RemoteOutputStream;
@@ -11,7 +12,6 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.tasks.SimpleBuildStep;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
@@ -56,7 +56,7 @@ public class MavenSnapshotCheck extends Builder implements SimpleBuildStep {
     }
 
     public String getPomFiles() {
-        if(StringUtils.isNotEmpty(pomFiles)){
+        if(Util.fixEmpty(pomFiles) != null){
             return pomFiles;
         }
         return DEFAULT_POM_FILES;


### PR DESCRIPTION
No need to depend on a third-party library here when the Java Platform provides this functionality natively.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

A single `StringUtils.isNotEmpty(pomFiles)` becomes `Util.fixEmpty(pomFiles) != null`, using the
`hudson.Util` helper. Also enables the `ban-commons-lang-2` enforcer rule.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
